### PR TITLE
ci: cache Playwright browsers, fix node-version matrix reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,24 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
-      - name: Set node version to ${{ inputs.node-version }}
+      - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ matrix.node_version }}
 
       - name: Install
         run: pnpm i
+
+      - name: Get Playwright version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Dependencies
         run: pnpm exec playwright install chromium --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,11 @@ jobs:
           path: ${{ github.workspace }}/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
+      # --with-deps only does anything on Linux (apt packages). On Windows it
+      # installs the Media Foundation feature (~3min, only needed for media
+      # playback), and on macOS it is a no-op.
       - name: Install Playwright Dependencies
-        run: pnpm exec playwright install chromium --with-deps
+        run: pnpm exec playwright install chromium ${{ runner.os == 'Linux' && '--with-deps' || '' }}
 
       - name: Test
         run: pnpm run test


### PR DESCRIPTION
## Changes

**Pass `--with-deps` only on Linux** — this is the actual Windows fix. The [Windows job log](https://github.com/vitest-tests/browser-examples/actions/runs/30462172492/job/90610761396) breaks the 3.5-minute install step down as:

- **3m06s** — `Install-WindowsFeature Server-Media-Foundation` (what `--with-deps` does on Windows for chromium)
- ~8s — downloading Chromium (191 MB)
- ~10s — extraction + ffmpeg

Media Foundation only provides media playback codecs, which these tests don't exercise, and `windows-latest` images don't ship it so it reinstalls on every run. On macOS `install-deps` is a no-op entirely (playwright only dispatches on `win32`/`linux`), and on Linux the apt packages are still installed via `--with-deps`.

**Cache Playwright browsers** — the workflow already redirects `PLAYWRIGHT_BROWSERS_PATH` into the workspace but never cached it. With the download at ~10s this is a minor win, but it shields against CDN slowness/outages. Keyed on the resolved `playwright` version so the ~200 MB cache only invalidates when Playwright updates, not on every Renovate bump. The install step stays unconditional — on a cache hit `playwright install` detects the browsers and skips the download.

**Fix `inputs.node-version`** — setup-node was reading `inputs.node-version`, which is always empty in this workflow, so it silently fell back to the runner's preinstalled Node. Now uses `matrix.node_version` as intended.